### PR TITLE
[minor] + updatetool dependency python-serial

### DIFF
--- a/chapter/gettingstarted/installation/firmwaretool.md
+++ b/chapter/gettingstarted/installation/firmwaretool.md
@@ -6,7 +6,7 @@ Here are the download links to the update tool. Please download the appropriate 
 
 - [Windows](https://software.pycom.io/findupgrade?product=pycom-firmware-updater&type=all&platform=win32&redirect=true)
 - [MacOS](https://software.pycom.io/findupgrade?product=pycom-firmware-updater&type=all&platform=macos&redirect=true) (10.11 or Higher)
-- [Linux](https://software.pycom.io/findupgrade?product=pycom-firmware-updater&type=all&platform=unix&redirect=true) (requires dialog package)
+- [Linux](https://software.pycom.io/findupgrade?product=pycom-firmware-updater&type=all&platform=unix&redirect=true) (requires dialog and python-serial package)
 
 {% hint style='info' %}
 Previous versions of firmware are available for download on the **[Pycom](https://www.pycom.io/downloads/)** website.


### PR DESCRIPTION
Minor change explicitly mentions  the additional updatetool dependency on `python-serial`. This dependency is listed in the README, but not the manual. The tool will run without the dependency, but result in a "Failure to connect error", leading to confusion.