### PR TITLE
Include button press as step in firmware updating instructions

### DIFF
--- a/chapter/gettingstarted/installation/firmwaretool.md
+++ b/chapter/gettingstarted/installation/firmwaretool.md
@@ -22,7 +22,7 @@ If you are having trouble connecting via USB, make sure you have the correct [FT
 
 1. Disconnect your device from your computer
 2. Connect a jumper cable or wire between G23 and GND
-3. Reconnect the board via USB to your computer, this puts the device in ‘firmware update mode’.
+3. Reconnect the board via USB to your computer, then press the button, this puts the device in ‘firmware update mode’.
 4. Run the Firmware Upgrade tool
 5. Remove the G23 to GND jumper cable/wire
 6. Reboot the device (button or power off then on)


### PR DESCRIPTION
firmware updater would not recognize my wipy on windows, unless i pressed the button after reconnection with the computer.