### PR TITLE
Fixed capitalization on while loop.

### DIFF
--- a/chapter/gettingstarted/programming/first_project.md
+++ b/chapter/gettingstarted/programming/first_project.md
@@ -100,7 +100,7 @@ import time
 
 pycom.heartbeat(False)
 
-While True:
+while True:
     pycom.rgbled(0xFF0000)  # Red
     time.sleep(1)
     pycom.rgbled(0x00FF00)  # Green


### PR DESCRIPTION
Attempting to copy/paste the first blinking LED example results in a syntax error. The error was the "while true" loop with a capital "While". Should be lowercase.