### PR TITLE
user experience fix

### DIFF
--- a/gettingstarted/installation/drivers.md
+++ b/gettingstarted/installation/drivers.md
@@ -16,7 +16,7 @@ All our products will work out of the box for Windows 8/10/+. If using Windows 7
 
 Please download the driver software from the link below.
 
-[Pysense/Pytrack/Pyscan/Expansion Board 3.0 Serial Driver](https://github.com/pycom/pycom-documentation/blob/master/pytrackpysense/installation/pycom.inf)
+[Pysense/Pytrack/Pyscan/Expansion Board 3.0 Serial Driver (save the file to your computer)](https://raw.githubusercontent.com/pycom/pycom-documentation/master/pytrackpysense/installation/pycom.inf)
 
 ### Installation
 


### PR DESCRIPTION
Changed the driver file URL to the Github "raw" link as several people do not understand how to "download" the driver from a blob. This change allows people to use typical File -> Save method, without any Github wizardry.