### PR TITLE
Fixed typo in first-project.md

### DIFF
--- a/gettingstarted/programming/first-project.md
+++ b/gettingstarted/programming/first-project.md
@@ -34,7 +34,7 @@ RGB-Blink
 
 * `boot.py` This is the first script that runs on your module when it
 
-  turns on. This is often used to connect a module a a WiFi network so that
+  turns on. This is often used to connect a module to a WiFi network so that
 
   Telnet and FTP can be used without connecting to the WiFi AP created by the
 


### PR DESCRIPTION
(Hi! 👋 Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

## What does this implement/fix? Explain your changes.
From: "This is often used to connect a module a a WiFi network so"
To: "This is often used to connect a module to a WiFi network so"

## Does this close any currently open issues?
Nope, small fix.

## Any relevant logs, error output, etc?
No

## Any other comments?
No

## Where has this been tested?
No testing needed. Typo in the guide.