### PR TITLE
remove unused pyscan modules

### DIFF
--- a/products.md
+++ b/products.md
@@ -79,25 +79,6 @@ Below you will find tables of all Pycom products. These tables illustrate the fu
       <td style="text-align:left">✔</td>
       <td style="text-align:left">✔</td>
     </tr>
-    <tr>
-     <td style="text-align:left">
-        <p>Pyscan Modules</p>
-        <p><a href="https://pycom.io/product/oled-screen/">OLED Module</a>
-        </p>
-        <p><a href="https://pycom.io/product/2mp-camera/">2MP Camera</a>
-        </p>
-        <p><a href="https://pycom.io/product/barcode-reader">Barcode Reader</a>
-        </p>
-        <p><a href="https://pycom.io/product/fingerprint-scanner/">Fingerprint Scanner</a>
-        </p>
-        <p><a href="https://pycom.io/product/infared-image-sensor/">IR Image Sensor</a>
-        </p>
-      </td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">✔</td>
-    </tr>
   </tbody>
 </table>## OEM Modules
 


### PR DESCRIPTION
(Hi! 👋 Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

## What does this implement/fix? Explain your changes.
 Pyscan Modules are currently unavailable and thus should not be linked in the documentation

## Does this close any currently open issues?
No


## Any relevant logs, error output, etc?
*(If it’s long, please paste to https://gist.github.com and insert the link here)*
N/A

## Any other comments?
N/A

## Where has this been tested?
- **Board type and hardware version:**
- **`os.uname()` output:**
- **Atom/VSCode version:**
- **Pymakr version:**
- **Operating system:**
N/A
