### PR TITLE
refactor: updated hugo to 0.58.3

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,12 +1,12 @@
-version: 0.1
+version: 0.2
 frontend:
   phases:
     build:
       commands:
-        - wget https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_0.54.0_Linux-64bit.tar.gz
-        - tar -xf hugo_0.54.0_Linux-64bit.tar.gz hugo
+        - wget https://github.com/gohugoio/hugo/releases/download/v0.58.3/hugo_0.58.3_Linux-64bit.tar.gz
+        - tar -xf hugo_0.58.3_Linux-64bit.tar.gz hugo
         - mv hugo /usr/bin/hugo
-        - rm -rf hugo_0.54.0_Linux-64bit.tar.gz
+        - rm -rf hugo_0.58.3_Linux-64bit.tar.gz
         - hugo
   artifacts:
     baseDirectory: public


### PR DESCRIPTION
Trying to fix the mangled characters in docs

this update will update only Hugo on development docs https://development.pycom.io