### PR TITLE
fix: added correct utf-8 encoding to the <head>

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html class="fancyScroll">
 <head>
+  <meta charset="utf-8">
   <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons" rel="stylesheet">
   <!--<link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">-->
   <link href="/css/vuetify.css" rel="stylesheet">


### PR DESCRIPTION
this fixes the mangled characters

https://discourse.gohugo.io/t/utf-8-characters-appear-garbled-in-prod/16910
https://discourse.gohugo.io/t/utf-8-characters-appear-garbled-in-prod-pt-2/20023