### PR TITLE
Make MDNS documentation visible

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -816,6 +816,13 @@ theme = "doc-theme"
     weight = 60
 
 [[menu.main]]
+    name = "MDNS"
+    url = "/firmwareapi/pycom/network/mdns/"
+    identifier = "firmwareapi@pycom@network@mdns"
+    parent = "firmwareapi@pycom@network"
+    weight = 70
+
+[[menu.main]]
     name = "AES"
     url = "/firmwareapi/pycom/aes/"
     identifier = "firmwareapi@pycom@aes"

--- a/content/firmwareapi/pycom/network/mdns.md
+++ b/content/firmwareapi/pycom/network/mdns.md
@@ -114,6 +114,7 @@ If the service is found then the function returns with a list of `MDNS_Query` ob
 ## MDNS_Query class
 
 The `MDNS_Query` aggregates all of the properties of a successful query session entry:
+
 * `hostname` is the hostname of the host advertising the service
 * `instance_name` is the instance_name of the service
 * `addr` is the IPv4 address belonging to the service


### PR DESCRIPTION
In https://github.com/pycom/pycom-documentation/pull/183 it was left out to add the MDNS documentation to the navigation bar.