### PR TITLE
Update README.md: pin_deepsleep_wakeup() renamed

### DIFF
--- a/content/firmwareapi/pycom/machine/README.md
+++ b/content/firmwareapi/pycom/machine/README.md
@@ -53,15 +53,15 @@ Stops the CPU and all peripherals, including the networking interfaces (except f
 
 The products with LTE connectivity (FiPy, GPy, G01), require the LTE radio to be disabled separately via the LTE class before entering deepsleep. This is required due to the LTE radio being powered independently and allowing use cases which require the system to be taken out from deepsleep by an event from the LTE network (data or SMS received for instance).
 
-#### machine.pin\_deepsleep\_wakeup(pins, mode, enable\_pull)
+#### machine.pin\_sleep\_wakeup(pins, mode, enable\_pull)
 
-Configure pins to wake up from deep sleep mode. The pins which have this capability are: `P2, P3, P4, P6, P8 to P10 and P13 to P23`.
+Configure pins to wake up from sleep mode. The pins which have this capability are: `P2, P3, P4, P6, P8 to P10 and P13 to P23`.
 
 The arguments are:
 
-* `pins` a list or tuple containing the `GPIO` to setup for deepsleep wakeup.
+* `pins` a list or tuple containing the `GPIO` to setup for sleep wakeup.
 * `mode` selects the way the configure `GPIO`s can wake up the module. The possible values are: `machine.WAKEUP_ALL_LOW` and `machine.WAKEUP_ANY_HIGH`.
-* `enable_pull` if set to `True` keeps the pull up or pull down resistors enabled during deep sleep. If this variable is set to `True`, then `ULP` or capacitive touch wakeup cannot be used in combination with `GPIO` wakeup.
+* `enable_pull` if set to `True` keeps the pull up or pull down resistors enabled during sleep. If this variable is set to `True`, then `ULP` or capacitive touch wakeup cannot be used in combination with `GPIO` wakeup.
 
 #### machine.wake\_reason()
 


### PR DESCRIPTION
pin_deepsleep_wakeup() renamed to pin_sleep_wakeup()

Issue: https://forum.pycom.io/topic/5606/what-happened-to-pin_deepsleep_wakeup 