### PR TITLE
Sigfox links should be under Pybytes > Networks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1370,20 +1370,6 @@ theme = "doc-theme"
     weight = 10
 
 [[menu.main]]
-    name = "DevKit contract"
-    url = "/pybytes/sigfox/devkit/"
-    identifier = "pybytes@sigfox@devkit"
-    parent = "pybytes@sigfox"
-    weight = 10
-
-[[menu.main]]
-    name = "Custom contract"
-    url = "/pybytes/sigfox/custom/"
-    identifier = "pybytes@sigfox@custom"
-    parent = "pybytes@sigfox"
-    weight = 20
-
-[[menu.main]]
     name = "Project Releases"
     url = "/pybytes/releases/"
     identifier = "pybytes@releases"


### PR DESCRIPTION
Sigfox links should not be in Pybytes main link options anymore