### PR TITLE
Add interface to save and resume SSL sessions (PR390)

### DIFF
--- a/content/firmwareapi/micropython/ussl.md
+++ b/content/firmwareapi/micropython/ussl.md
@@ -10,9 +10,9 @@ This module provides access to Transport Layer Security (often known as "Secure 
 
 ## Methods
 
-#### ssl.wrap\_socket(sock, keyfile=None, certfile=None, server\_side=False, cert\_reqs=CERT\_NONE, ca\_certs=None\, timeout=10sec)
+#### ssl.wrap\_socket(sock, keyfile=None, certfile=None, server\_side=False, cert\_reqs=CERT\_NONE, ssl\_version=0, ca\_certs=None, server\_hostname=None, saved_session=None, timeout=10sec)
 
-Takes an instance `sock` of `socket.socket`, and returns an instance of ssl.SSLSocket, a subtype of `socket.socket`, which wraps the underlying socket in an SSL context. Example:
+Takes an instance `sock` of `socket.socket`, and returns an instance of `ssl.SSLSocket`, a subtype of `socket.socket`, which wraps the underlying socket in an SSL context. Example:
 
 ```python
 
@@ -38,7 +38,26 @@ ss.connect(socket.getaddrinfo('cloud.blynk.cc', 8441)[0][-1])
 
 SSL sockets inherit all methods and from the standard sockets, see the `usocket` module.
 
+`saved_session` : Takes a saved session instance of `ssl.SSLSocket`, and retrieve an already established TLS connection.
+
 `timeout` : specify a Timeout in Seconds for the SSL handshake operation between client and server, default is 10 seconds
+
+#### ssl.save\_session(ssl_sock)
+
+Takes an instance `ssl_sock` of `ssl.SSLSocket`, and returns an instance of `ssl.SSLSession`. Saved session can be resumed later, thereby reducing mobile data and time required. Example:
+
+```python
+
+import socket
+import ssl
+s = socket.socket()
+ss = ssl.wrap_socket(s)
+ss.connect(socket.getaddrinfo('www.google.com', 443)[0][-1])
+ses = ssl.save_session(ss)
+ss.close()
+ss = ssl.wrap_socket(s, saved_session=ses)
+ss.connect(socket.getaddrinfo('www.google.com', 443)[0][-1])
+```
 
 ## Exceptions
 
@@ -47,4 +66,3 @@ SSL sockets inherit all methods and from the standard sockets, see the `usocket`
 ## Constants
 
 * `ssl.CERT_NONE`, `ssl.CERT_OPTIONAL`, `ssl.CERT_REQUIRED`: Supported values in `cert_reqs`
-


### PR DESCRIPTION
To be merged when the feature is released in a stable release.
Feature is released as development version: not released yet 
Documentation PR of the development version: https://github.com/pycom/pycom-documentation/pull/226 