### PR TITLE
fix: Pybytes IOS option was not on the menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1391,6 +1391,13 @@ theme = "doc-theme"
     weight = 20
 
 [[menu.main]]
+  name = "Pybytes iOS"
+  url = "/pybytes/smart/"
+  identifier = "pybytes@smart"
+  parent = "pybytes"
+  weight = 20
+
+[[menu.main]]
     name = "Networks"
     url = "/pybytes/networks/"
     identifier = "pybytes@networks"


### PR DESCRIPTION
fix: PB-930 Pybytes iOS provisioning page is not shown in docs