### PR TITLE
fixes to docs and development merging

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -395,6 +395,8 @@ theme = "doc-theme"
     identifier = "tutorials@expansionboards@pygate"
     parent = "tutorials@expansionboards"
     weight = 10
+    pre = "dev"
+
 [[menu.main]]
     name = "pysense"
     url = "/tutorials/expansionboards/pysense"
@@ -444,7 +446,7 @@ theme = "doc-theme"
     url = "/firmwareapi/"
     identifier = "firmwareapi"
     weight = 70
-
+        
 [[menu.main]]
     name = "Pycom Modules"
     url = "/firmwareapi/pycom/"
@@ -769,7 +771,6 @@ theme = "doc-theme"
     identifier = "firmwareapi@micropython@micropython"
     parent = "firmwareapi@micropython"
     weight = 50
-
 [[menu.main]]
     name = "uctypes"
     url = "/firmwareapi/micropython/uctypes/"

--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,17 @@ PygmentsCodeFences = true
 PygmentsStyle = "friendly"
 theme = "doc-theme"
 
+
+[languages]
+    [languages.en]
+        languageName= "Stable"
+        contentDir = "content/"
+        weight=1
+    [languages.dev]
+        languageName = "Development"
+        contentDir = "content/"
+        weight=2
+
 [menu]
 
 [[menu.main]]

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,7 +24,7 @@ Connect your device to your own IoT platform with one of the advertised wireless
 This usually requires some registration. This step will detail how to get registered and connected to various wireless networks.
 
 # Quick navigation
-* [Products](/products/)
+* [Products]({{<relref "products">}})
 * [Pymakr](/gettingstarted/software/)
 * [Tutorials](/tutorials/)
 * [API Documentation](/firmwareapi/)

--- a/content/firmwareapi/pycom/machine/adc.md
+++ b/content/firmwareapi/pycom/machine/adc.md
@@ -30,7 +30,7 @@ val = apin()                    # read an analog value
 
 ## Constructors
 
-### class machine.ADC([id=0])
+### class machine.ADC([id=0] {{% development version="" style="inline" %}}hello  {{% /development %}})
 
 Create an ADC object; associate a channel with a pin. For more info check the hardware section.
 

--- a/content/firmwareapi/pycom/network/eth.md
+++ b/content/firmwareapi/pycom/network/eth.md
@@ -5,6 +5,8 @@ aliases:
     - firmwareapi/pycom/network/eth.md
     - chapter/firmwareapi/pycom/network/eth
 ---
+{{% development version="" style="dev" %}}
+ 
 
 The ETH class enables the use of an ethernet connection via the PyEthernet board plugged into a Pygate.
 
@@ -65,3 +67,4 @@ Shuts down the ethernet interface.
 ### eth.isconnected()
 
 Returns `True` if the ethernet link is up and IP is accquired, `False` otherwise.
+{{% /development %}}

--- a/content/tutorials/expansionboards/pygate.md
+++ b/content/tutorials/expansionboards/pygate.md
@@ -1,3 +1,8 @@
+---
+title: "Pygate"
+
+---
+{{% development version="" style="page" %}}
 ## Pygate
 
 The Pygate is an 8-channel LoRaWAN gateway. This page will help you get started with it.
@@ -296,3 +301,4 @@ A sample `config.json` file for gateway configuration in EU868 region:
 	}
 }
 ```
+{{% /development %}}

--- a/content/tutorials/expansionboards/pygate.md
+++ b/content/tutorials/expansionboards/pygate.md
@@ -2,6 +2,8 @@
 title: "Pygate"
 
 ---
+This page contains development information. Switch to the development documentation by using the options in the top right corner
+
 {{% development version="" style="page" %}}
 ## Pygate
 

--- a/layouts/_default/404.html
+++ b/layouts/_default/404.html
@@ -1,7 +1,7 @@
 {{ define "main"}}
     <main id="main">
       <div>
-       <h1 id="title"><a href="{{ "/" | relURL }}">Go Home</a></h1>
+       <h1 id="title"><a href="{{ "/" | relLangURL }}">Go Home</a></h1>
       </div>
     </main>
 {{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -48,12 +48,12 @@
         drawer2: true,
         toc: 0,
         branches: [
-        { value: 'https://docs.pycom.io', text: 'version stable'},
-        { value: 'https://development.pycom.io', text: 'version development'},
-          /*{ value: '1', text: 'version 1.20.2.r0'},
-          { value: '2', text: 'version 1.20.3.b0'},
-          { value: '3', text: 'version 1.20.2.rc10'},
-          { value: '4', text: 'version 1.20.2.rc9'},*/
+        { value: '', text: 'latest'},
+        { value: 'dev', text: 'version development'},
+          /*{ value: '1.20.2.r0', text: 'version 1.20.2.r0'},
+          { value: '1.20.3.b0', text: 'version 1.20.3.b0'},
+          { value: '1.20.2.rc10', text: 'version 1.20.2.rc10'},
+          { value: '1.20.2.rc9', text: 'version 1.20.2.rc9'},*/
         ],
         branch: ""
       },
@@ -65,19 +65,14 @@
             this.branch= this.branches[b]
           }
         }
-        if(window.location.host == "localhost:1313" || window.location.host == "development.pycom.io"){
-          var x = document.getElementsByClassName('development')
-          var i;
-          for (i = 0; i < x.length; i++) {
-            x[i].style.display = 'inline';
-          }
-        }else{
-          var x = document.getElementsByClassName('development')
-          var i;
-          for (i = 0; i < x.length; i++) {
-            x[i].style.display = 'none';
-          }
+        var li = document.links;
+        targetVersion = this.branch.value;
+        console.log(targetVersion);
+        for(var i = 0; i< li.length; i++){
+          li[i].href = "/" +targetVersion + li[i].href;
+          console.log(li[i].href);
         }
+
         // there is not always a toc button
         // temp. show page-toc to the user as hint of existence
         if (this.$refs.tocBtn) {
@@ -93,24 +88,27 @@
       },
       watch: {
         // whenever the branch changes, this function will run
-        branch: function (newb, old) {
+        branch: function (newb, currentb) {
           if (newb.value != this.branches[0].value) {
-          //   development = !development;
-          //   console.log("switch")
-          //   if (!development){
-          //     var x = document.getElementsByClassName('development')
-          //     var i;
-          //     for (i = 0; i < x.length; i++) {
-          //       x[i].style.display = 'none';
-          //     }   
-          //   }else{
-          //     var x = document.getElementsByClassName('development')
-          //     var i;
-          //     for (i = 0; i < x.length; i++) {
-          //       x[i].style.display = 'block';
-          //     }   
-          //   }
-            window.location = newb + window.location.pathname;
+              var targetVersion = newb;
+              var currentVersion = currentb.value;
+              if (currentVersion !== targetVersion) {
+                console.log("targetversion: ",targetVersion);
+                console.log("currentVersion: ", currentVersion);
+                var basePath = getPathBeforeVersionName(location, currentVersion);
+                console.log("basePath: ",basePath);
+                // Getting everything after targetVersion and concatenating it with the hash part.
+                var currentPath = getPathAfterVersionName(location, currentVersion);
+                console.log("Currentpath:",currentPath);
+                var targetPath;
+                if (targetVersion === "") {
+                  targetPath = basePath + currentPath;
+                } else {
+                  targetPath = basePath + targetVersion + "/" + currentPath;
+                }
+                console.log("targetPath:", targetPath);
+                //location.assign(targetPath);
+              }
           }
         },
       },
@@ -123,6 +121,29 @@
       inputSelector: '.algolia-search-field input',
       debug: false // Set debug to true if you want to inspect the dropdown
     });
+
+
+    function getPathBeforeVersionName(location, versionName) {
+      return "/";
+    }
+
+    // getPathAfterVersionName gets the current URL path after the version prefix
+    function getPathAfterVersionName(location, versionName) {
+      let path;
+      if (versionName === "") {
+        path = location.pathname
+          .split("/")
+          .slice(1)
+          .join("/");
+      } else {
+        path = location.pathname
+          .split("/")
+          .slice(2)
+          .join("/");
+      }
+
+      return path + location.hash;
+    }
   </script>
 <!--{{- partial "footer.html" . -}}-->
 {{- partial "alexia.html" . -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -65,11 +65,11 @@
             this.branch= this.branches[b]
           }
         }
-        if(window.location.host == "development.pycom.io"){
+        if(window.location.host == "localhost:1313" || window.location.host == "development.pycom.io"){
           var x = document.getElementsByClassName('development')
           var i;
           for (i = 0; i < x.length; i++) {
-            x[i].style.display = 'block';
+            x[i].style.display = 'inline';
           }
         }else{
           var x = document.getElementsByClassName('development')

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -49,7 +49,7 @@
         toc: 0,
         branches: [
         { value: 'https://docs.pycom.io', text: 'version stable'},
-          { value: 'https://development.pycom.io', text: 'version development'},
+        { value: 'https://development.pycom.io', text: 'version development'},
           /*{ value: '1', text: 'version 1.20.2.r0'},
           { value: '2', text: 'version 1.20.3.b0'},
           { value: '3', text: 'version 1.20.2.rc10'},
@@ -63,6 +63,19 @@
         for (b in this.branches) {
           if ( document.location.href.indexOf(this.branches[b].value) > -1) {
             this.branch= this.branches[b]
+          }
+        }
+        if(window.location.host == "development.pycom.io"){
+          var x = document.getElementsByClassName('development')
+          var i;
+          for (i = 0; i < x.length; i++) {
+            x[i].style.display = 'block';
+          }
+        }else{
+          var x = document.getElementsByClassName('development')
+          var i;
+          for (i = 0; i < x.length; i++) {
+            x[i].style.display = 'none';
           }
         }
         // there is not always a toc button

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,6 +19,8 @@
 <body>
 </script>
 <v-app id="app" class=""  v-cloak style="background-color: white;">
+
+  
    {{ partial "menu.html" . }}
    {{- partial "toolbar.html" . -}}
    <v-content >
@@ -48,8 +50,8 @@
         drawer2: true,
         toc: 0,
         branches: [
-        { value: '', text: 'latest'},
-        { value: 'dev', text: 'version development'},
+        { value: '/', text: 'latest'},
+        { value: '/dev/', text: 'version development'},
           /*{ value: '1.20.2.r0', text: 'version 1.20.2.r0'},
           { value: '1.20.3.b0', text: 'version 1.20.3.b0'},
           { value: '1.20.2.rc10', text: 'version 1.20.2.rc10'},
@@ -64,13 +66,6 @@
           if ( document.location.href.indexOf(this.branches[b].value) > -1) {
             this.branch= this.branches[b]
           }
-        }
-        var li = document.links;
-        targetVersion = this.branch.value;
-        console.log(targetVersion);
-        for(var i = 0; i< li.length; i++){
-          li[i].href = "/" +targetVersion + li[i].href;
-          console.log(li[i].href);
         }
 
         // there is not always a toc button
@@ -90,25 +85,7 @@
         // whenever the branch changes, this function will run
         branch: function (newb, currentb) {
           if (newb.value != this.branches[0].value) {
-              var targetVersion = newb;
-              var currentVersion = currentb.value;
-              if (currentVersion !== targetVersion) {
-                console.log("targetversion: ",targetVersion);
-                console.log("currentVersion: ", currentVersion);
-                var basePath = getPathBeforeVersionName(location, currentVersion);
-                console.log("basePath: ",basePath);
-                // Getting everything after targetVersion and concatenating it with the hash part.
-                var currentPath = getPathAfterVersionName(location, currentVersion);
-                console.log("Currentpath:",currentPath);
-                var targetPath;
-                if (targetVersion === "") {
-                  targetPath = basePath + currentPath;
-                } else {
-                  targetPath = basePath + targetVersion + "/" + currentPath;
-                }
-                console.log("targetPath:", targetPath);
-                //location.assign(targetPath);
-              }
+            //window.location = newb + window.location.pathname;
           }
         },
       },
@@ -121,29 +98,6 @@
       inputSelector: '.algolia-search-field input',
       debug: false // Set debug to true if you want to inspect the dropdown
     });
-
-
-    function getPathBeforeVersionName(location, versionName) {
-      return "/";
-    }
-
-    // getPathAfterVersionName gets the current URL path after the version prefix
-    function getPathAfterVersionName(location, versionName) {
-      let path;
-      if (versionName === "") {
-        path = location.pathname
-          .split("/")
-          .slice(1)
-          .join("/");
-      } else {
-        path = location.pathname
-          .split("/")
-          .slice(2)
-          .join("/");
-      }
-
-      return path + location.hash;
-    }
   </script>
 <!--{{- partial "footer.html" . -}}-->
 {{- partial "alexia.html" . -}}

--- a/layouts/shortcodes/development.html
+++ b/layouts/shortcodes/development.html
@@ -1,12 +1,18 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class='development'>
-<v-card class='{{ .Get "style" }}'>
+  {{ if ne (.Get "style") ("inline")}}
+<v-card class='dev'>
     <v-card-text>
       Development version {{.Get "version" }}
       {{ .Inner }}
   
     </v-card-text>
 </v-card>
+{{else}}
+<div class='dev' style="display:inline">
+{{.Inner}}
+</div>
+{{end}}
 </div>
 
 

--- a/layouts/shortcodes/development.html
+++ b/layouts/shortcodes/development.html
@@ -1,18 +1,19 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class='development'>
-  {{ if ne (.Get "style") ("inline")}}
-<v-card class='dev'>
-    <v-card-text>
-      Development version {{.Get "version" }}
-      {{ .Inner }}
-  
-    </v-card-text>
-</v-card>
-{{else}}
-<div class='dev' style="display:inline">
-{{.Inner}}
-</div>
-{{end}}
+    {{ if ne (.Get "style") ("inline")}}
+  <v-card class='dev'>
+      <v-card-text>
+        <!--Development version {{.Get "version" }}-->
+        {{ .Inner }}
+    
+      </v-card-text>
+  </v-card>
+  {{else}}
+  <div class='dev' style="display:inline">
+  {{.Inner}}
+  </div>
+  {{end}}
+
 </div>
 
 

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html class="fancyScroll">
+<head>
+  <meta charset="utf-8">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons" rel="stylesheet">
+  
+  <link href="/css/vuetify.css" rel="stylesheet">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
+
+  <title>404 Page not found </title>
+  <meta name="description" content="">
+
+  <script src="/js/smooth-scroll.js"></script>
+  <link href="/css/doc-theme.css?" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico">
+  
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+</head>
+<body>
+</script>
+<v-app id="app" class=""  v-cloak style="background-color: white;">
+
+  
+   <v-navigation-drawer
+  v-model="drawer"
+  fixed
+  app
+  class="lighten-4 pt-0"
+  style="overflow-y: hidden; overflow-x: hidden;margin-top:68px;"
+>
+
+  <div class="fancyScroll pa-0 ma-0" style="overflow-y: scroll; overflow-x: hidden;
+      max-height: 100%;" >
+
+    <v-divider class="mr-2 ml-1 mb-4" style="border: 0"></v-divider>
+
+      <ul class="lefttree">
+        <li class="lefttree">
+            <a href="/" class="beba" style="color: #1E1E3C; text-decoration: none;" >
+              <v-icon style="color: #1E1E3C;" class="mr-1" >home</v-icon> Introduction</a>
+        </li>
+      </ul>
+
+    
+
+
+<ul class="lefttree ">
+
+  
+  
+  
+  
+  
+
+
+    <li class="lefttree ">
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/products/" class="">Pycom Products</a>
+    </li>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/gettingstarted/" class=""> Getting Started</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/tutorials/" class=""> Tutorials &amp; Examples</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/firmwareapi/" class=""> Firmware &amp; API Reference</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/datasheets/" class=""> Product Info, Datasheets</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/updatefirmware/" class=""> Update Firmware</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/pybytes/" class=""> Pybytes</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/cellularservices/" class=""> Cellular Services</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/pymesh/" class=""> Pymesh</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/docnotes/" class=""> Micropython Support</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <li class="lefttree " >
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/advance/downgrade/" class=""> Advanced topics</a>
+      
+      
+
+      
+
+  
+
+  
+  
+  
+  
+  
+
+
+    <li class="lefttree ">
+      <v-icon style="color: transparent; display: hidden;" >done</v-icon>
+      <a href="/license/" class="">License</a>
+    </li>
+
+  
+
+</ul>
+
+
+    <v-divider class="grey lighten-1 ma-2 mt-4 mb-4"></v-divider>
+
+    <ul class="lefttree" >Have a question ?
+      <li class="lefttree">  <a href="https://forum.pycom.io">Ask on the forum</a>
+        
+    </ul>
+    <p>&nbsp;</p>
+    <li class="lefttree"> <a href="" class="dev">Development Feature</a></li>
+      <p>&nbsp;</p>
+
+      <ul>
+
+<li><a href="https://docs.pycom.io/">Stable</a></li>
+
+<li><a href="https://docs.pycom.io/dev/">Development</a></li>
+
+</ul>
+      
+  </div>
+</v-navigation-drawer>
+<v-toolbar
+  app
+  fixed
+  height=68
+  class="pr-3 pl-2 navbar"
+  dark
+  style="background-color: #171730;"
+  flat
+>
+  <v-toolbar-title style="width: 260px; " class="ml-4 pl-0  pt-2 text-xs-center hidden-sm-and-down">
+    <v-img class="ml-4"  height=48 width=190  src="/logo.svg" class="">
+  </v-toolbar-title>
+
+    <v-btn icon @click.stop="drawer = !drawer" style="z-index: 1200;">
+      <v-icon>toc</v-icon>
+    </v-btn>
+    <span class="beba" style="font-size: 1.6rem; opacity: 0.85;">
+        404 Page not found
+    </span>
+
+  <v-text-field
+    style="max-width: 650px"
+    class="ml-3 algolia-search-field"
+    light
+    hide-details
+    label="Search the docs..."
+    solo
+    append-icon="search"
+  ></v-text-field>
+
+  <v-spacer></v-spacer>
+
+  <div style="width: 240px;">
+  <v-select :items="branches" v-model="branch" width=120 class="mono">
+  </v-select>
+  </div>
+  
+</v-toolbar>
+<v-content >
+      <v-container class="fluid pa-4" style="padding-top: 0 !important;">
+          <v-container class="ma-1 pa-1">
+
+    <main id="main">
+      <div>
+       <h1 id="title">404 - Page not found</h1>
+      </div>
+    </main>
+
+          </v-container>
+      </v-container>
+    </v-content>
+ </v-app>
+
+  <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vuetify/1.5.13/vuetify.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-resource/1.5.1/vue-resource.min.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+  <script>
+    var development = false;
+    var app = new Vue({
+      el: '#app',
+      data: {
+        page: 1,
+        pageCount: 0,
+        error: null,
+        results: null,
+        drawer: true,
+        drawer2: true,
+        toc: 0,
+        branches: [
+        { value: '/', text: 'latest'},
+        { value: '/dev/', text: 'version development'},
+          
+
+        ],
+        branch: ""
+      },
+      mounted: function () {
+        
+        this.branch= this.branches[0]
+        for (b in this.branches) {
+          if ( document.location.href.indexOf(this.branches[b].value) > -1) {
+            this.branch= this.branches[b]
+          }
+        }
+
+        
+        
+        if (this.$refs.tocBtn) {
+          var elem = this.$refs.tocBtn.$el
+          setTimeout(function () {
+              elem.click();
+
+          }, 3500);
+        }
+        var elem2 = document.getElementById("vuetify-theme-stylesheet");
+        elem2.parentNode.removeChild(elem2);
+
+      },
+      watch: {
+        
+        branch: function (newb, currentb) {
+          if (newb.value != this.branches[0].value) {
+            
+          }
+        },
+      },
+    });
+
+    
+    docsearch({
+      apiKey: 'a99fde9999fbec81c1772eb9ffcca488',
+      indexName: 'pycom',
+      inputSelector: '.algolia-search-field input',
+      debug: false 
+    });
+  </script>
+<script type="text/javascript">
+_atrk_opts = { atrk_acct:"WpWNq1SZw320l9", domain:"pycom.io",dynamic: true};
+(function() { var as = document.createElement('script'); as.type = 'text/javascript'; as.async = true; as.src = "https://certify-js.alexametrics.com/atrk.js"; var s = document.getElementsByTagName('script')[0];s.parentNode.insertBefore(as, s); })();
+</script>
+<noscript><img src="https://certify.alexametrics.com/atrk.gif?account=WpWNq1SZw320l9" style="display:none" height="1" width="1" alt="" /></noscript>
+
+
+<script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:1216663,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-72107804-3', 'auto');
+ga('send', 'pageview');
+</script>
+</body>
+</html>

--- a/themes/doc-theme/layouts/partials/menu.html
+++ b/themes/doc-theme/layouts/partials/menu.html
@@ -24,8 +24,11 @@
 
     <ul class="lefttree" >Have a question ?
       <li class="lefttree">  <a href="https://forum.pycom.io">Ask on the forum</a>
+        
     </ul>
     <p>&nbsp;</p>
+    <li class="lefttree"> <a href="" class="dev">Development Feature</a></li>
       <p>&nbsp;</p>
+      
   </div>
 </v-navigation-drawer>

--- a/themes/doc-theme/layouts/partials/menu.html
+++ b/themes/doc-theme/layouts/partials/menu.html
@@ -29,6 +29,12 @@
     <p>&nbsp;</p>
     <li class="lefttree"> <a href="" class="dev">Development Feature</a></li>
       <p>&nbsp;</p>
+
+      <ul>
+{{ range $.Site.Home.AllTranslations }}
+<li><a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a></li>
+{{ end }}
+</ul>
       
   </div>
 </v-navigation-drawer>

--- a/themes/doc-theme/layouts/partials/menu_recursive.html
+++ b/themes/doc-theme/layouts/partials/menu_recursive.html
@@ -12,7 +12,7 @@
   {{ if true }}
     <li class="lefttree {{ if or $iz $haz }}padleft hot{{ end }}" >
       <v-icon style="color: transparent; display: hidden;" >done</v-icon>
-      <a href="{{ .URL | relURL }}" class="{{ if or $iz $haz }}hot{{end}}"> {{ .Pre }} {{ .Name }}</a>
+      <a href="{{ .URL | relURL }}" class="{{ if or $iz $haz }}hot{{end}} {{ if eq (print .Pre) "dev" }}dev{{end}}"> {{ .Name }}</a>
       {{ end }}
       {{ if or $iz $haz $phaz }}
         {{ partial "menu_recursive.html" (dict "menu" .Children "page" $page "level" $level ) }}
@@ -27,7 +27,7 @@
 
     <li class="lefttree {{ if $haz }}hot{{end}}">
       <v-icon style="color: transparent; display: hidden;" >done</v-icon>
-      <a href="{{ .URL | relURL }}" class="{{ if $iz }}hot{{end}}">{{ .Name }}</a>
+      <a href="{{ .URL | relURL }}" class="{{ if $iz }}hot{{end}} {{ if eq (print .Pre) "dev" }}dev{{end}}">{{ .Name }}</a>
     </li>
 
   {{ end }}

--- a/themes/doc-theme/layouts/partials/menu_recursive.html
+++ b/themes/doc-theme/layouts/partials/menu_recursive.html
@@ -12,7 +12,7 @@
   {{ if true }}
     <li class="lefttree {{ if or $iz $haz }}padleft hot{{ end }}" >
       <v-icon style="color: transparent; display: hidden;" >done</v-icon>
-      <a href="{{ .URL | relURL }}" class="{{ if or $iz $haz }}hot{{end}} {{ if eq (print .Pre) "dev" }}dev{{end}}"> {{ .Name }}</a>
+      <a href="{{ .URL | relLangURL }}" class="{{ if or $iz $haz }}hot{{end}}"> {{ .Name }}</a>
       {{ end }}
       {{ if or $iz $haz $phaz }}
         {{ partial "menu_recursive.html" (dict "menu" .Children "page" $page "level" $level ) }}
@@ -27,7 +27,7 @@
 
     <li class="lefttree {{ if $haz }}hot{{end}}">
       <v-icon style="color: transparent; display: hidden;" >done</v-icon>
-      <a href="{{ .URL | relURL }}" class="{{ if $iz }}hot{{end}} {{ if eq (print .Pre) "dev" }}dev{{end}}">{{ .Name }}</a>
+      <a href="{{ .URL | relLangURL }}" class="{{ if $iz }}hot{{end}}">{{ .Name }}</a>
     </li>
 
   {{ end }}

--- a/themes/doc-theme/layouts/partials/toolbar.html
+++ b/themes/doc-theme/layouts/partials/toolbar.html
@@ -29,12 +29,12 @@
   ></v-text-field>
 
   <v-spacer></v-spacer>
-  {{ if eq .Section "firmwareapi"}}
+{{/* if eq .Section "firmwareapi" */}}
   <div style="width: 240px;">
   <v-select :items="branches" v-model="branch" width=120 class="mono">
   </v-select>
   </div>
-  {{ end }}
+  {{/* end */}}
   {{- if gt .WordCount 400 -}}
   <v-btn icon ref="tocBtn" @click.stop="drawer2 = !drawer2" >
     <v-icon style="color: rgb(23, 255, 189);">more_vert</v-icon>


### PR DESCRIPTION
This only works on the actual hostnames (docs.pycom.io and development.pycom.io) unfortunately. 
If we make development.pycom.io point to exact the same pages of docs.pycom.io while keeping the correct hostname (not http redirect), we can toggle the development blocks on and off on all pages