### PR TITLE
Updates decremented .readall() to .read()

### DIFF
--- a/content/firmwareapi/pycom/machine/sd.md
+++ b/content/firmwareapi/pycom/machine/sd.md
@@ -33,7 +33,7 @@ f = open('/sd/test.txt', 'w')
 f.write('Testing SD card write operations')
 f.close()
 f = open('/sd/test.txt', 'r')
-f.readall()
+f.read()
 f.close()
 ```
 


### PR DESCRIPTION
`.readall()` in the example didn't work for me, it appears it has been decremented. 
I have tried with `.read()` instead and this works for me. 