### PR TITLE
update to Pycom colors

### DIFF
--- a/themes/doc-theme/static/css/doc-theme.css
+++ b/themes/doc-theme/static/css/doc-theme.css
@@ -62,7 +62,7 @@ h2 {
 }
 h3 {
   font-family: 'Montserrat';
-  color: rgb(0,112,32);
+  color:#00CC96  ;
   letter-spacing: normal;
   font-size: 1em;
   padding-top: 1em;

--- a/themes/doc-theme/static/css/vuetify.css
+++ b/themes/doc-theme/static/css/vuetify.css
@@ -2754,7 +2754,7 @@ blockquote {
   padding: 10px 10px 10px 10px;
   font-size: 14px;
   font-weight: 300;
-  background-color:rgba(0,128,0,0.7);
+  background-color:#17ffbd;
   border-radius: 3px;
   margin-bottom: 5px;  
 }


### PR DESCRIPTION
Update the documentation to use Pycom green for the blockquotes and heading 3.