### PR TITLE
pygate: close config file to save ram

### DIFF
--- a/content/tutorials/expansionboards/pygate.md
+++ b/content/tutorials/expansionboards/pygate.md
@@ -100,8 +100,8 @@ while not rtc.synced():
 print(" OK\n")
 
 # Read the GW config file from Filesystem
-fp = open('/flash/config.json','r')
-buf = fp.read()
+with open('/flash/config.json','r') as fp:
+    buf = fp.read()
 
 # Start the Pygate
 machine.pygate_init(buf)


### PR DESCRIPTION
e.g. on 1.20.3.b3 on a wipy this makes the difference between immediate out of memory or able to start